### PR TITLE
start location option

### DIFF
--- a/lib/walex/config/config.ex
+++ b/lib/walex/config/config.ex
@@ -6,7 +6,7 @@ defmodule WalEx.Config do
 
   alias WalEx.Config.Registry, as: WalExRegistry
 
-  @allowed_config_value ~w(database hostname name password port publication username webhook_signing_secret slot_name)a
+  @allowed_config_value ~w(database hostname name password port publication username webhook_signing_secret slot_name durable_slot)a
   @allowed_config_values ~w(destinations event_relay modules subscriptions)a
 
   def start_link(opts) do
@@ -126,7 +126,8 @@ defmodule WalEx.Config do
       destinations: Keyword.put(destinations, :modules, module_names),
       webhook_signing_secret: Keyword.get(configs, :webhook_signing_secret),
       event_relay: Keyword.get(configs, :event_relay),
-      slot_name: Keyword.get(configs, :slot_name) |> parse_slot_name(name)
+      slot_name: Keyword.get(configs, :slot_name) |> parse_slot_name(name),
+      durable_slot: Keyword.get(configs, :durable_slot, false) == true
     ]
   end
 

--- a/lib/walex/config/config.ex
+++ b/lib/walex/config/config.ex
@@ -6,7 +6,7 @@ defmodule WalEx.Config do
 
   alias WalEx.Config.Registry, as: WalExRegistry
 
-  @allowed_config_value ~w(database hostname name password port publication username webhook_signing_secret slot_name durable_slot)a
+  @allowed_config_value ~w(database hostname name password port publication username webhook_signing_secret slot_name durable_slot start_location)a
   @allowed_config_values ~w(destinations event_relay modules subscriptions)a
 
   def start_link(opts) do
@@ -127,7 +127,8 @@ defmodule WalEx.Config do
       webhook_signing_secret: Keyword.get(configs, :webhook_signing_secret),
       event_relay: Keyword.get(configs, :event_relay),
       slot_name: Keyword.get(configs, :slot_name) |> parse_slot_name(name),
-      durable_slot: Keyword.get(configs, :durable_slot, false) == true
+      durable_slot: Keyword.get(configs, :durable_slot, false) == true,
+      start_location: Keyword.get(configs, :start_location) |> parse_start_location()
     ]
   end
 
@@ -199,6 +200,10 @@ defmodule WalEx.Config do
 
   defp parse_slot_name(nil, app_name), do: to_string(app_name) <> "_walex"
   defp parse_slot_name(slot_name, _), do: slot_name
+
+  defp parse_start_location(nil), do: {:value, "0/0"}
+  defp parse_start_location(callback) when is_function(callback, 0), do: {:callback, callback}
+  defp parse_start_location(lsn) when is_binary(lsn), do: {:value, lsn}
 
   defp set_url_opts(username, password, database, info) do
     url_opts = [

--- a/lib/walex/replication/query_builder.ex
+++ b/lib/walex/replication/query_builder.ex
@@ -3,8 +3,16 @@ defmodule WalEx.Replication.QueryBuilder do
     "SELECT 1 FROM pg_publication WHERE pubname = '#{state.publication}' LIMIT 1;"
   end
 
+  def slot_exists(state) do
+    "SELECT active FROM pg_replication_slots WHERE slot_name = '#{state.slot_name}' LIMIT 1;"
+  end
+
   def create_temporary_slot(state) do
     "CREATE_REPLICATION_SLOT #{state.slot_name} TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT;"
+  end
+
+  def create_durable_slot(state) do
+    "CREATE_REPLICATION_SLOT #{state.slot_name} LOGICAL pgoutput NOEXPORT_SNAPSHOT;"
   end
 
   def start_replication_slot(state) do

--- a/lib/walex/replication/query_builder.ex
+++ b/lib/walex/replication/query_builder.ex
@@ -16,6 +16,12 @@ defmodule WalEx.Replication.QueryBuilder do
   end
 
   def start_replication_slot(state) do
-    "START_REPLICATION SLOT #{state.slot_name} LOGICAL 0/0 (proto_version '1', publication_names '#{state.publication}')"
+    start_location =
+      case state.start_location do
+        {:value, lsn} -> lsn
+        {:callback, callback} -> callback.()
+      end
+
+    "START_REPLICATION SLOT #{state.slot_name} LOGICAL #{start_location} (proto_version '1', publication_names '#{state.publication}')"
   end
 end

--- a/lib/walex/replication/server.ex
+++ b/lib/walex/replication/server.ex
@@ -48,12 +48,14 @@ defmodule WalEx.Replication.Server do
     [
       slot_name: slot_name,
       publication: publication,
-      durable_slot: durable_slot
+      durable_slot: durable_slot,
+      start_location: start_location
     ] =
       WalEx.Config.get_configs(app_name, [
         :slot_name,
         :publication,
-        :durable_slot
+        :durable_slot,
+        :start_location
       ])
 
     state = %{
@@ -61,7 +63,8 @@ defmodule WalEx.Replication.Server do
       app_name: app_name,
       slot_name: slot_name,
       publication: publication,
-      durable_slot: durable_slot
+      durable_slot: durable_slot,
+      start_location: start_location
     }
 
     {:ok, state}

--- a/lib/walex/replication/server.ex
+++ b/lib/walex/replication/server.ex
@@ -45,17 +45,23 @@ defmodule WalEx.Replication.Server do
   def init(opts) do
     app_name = Keyword.get(opts, :app_name)
 
-    [slot_name: slot_name, publication: publication] =
+    [
+      slot_name: slot_name,
+      publication: publication,
+      durable_slot: durable_slot
+    ] =
       WalEx.Config.get_configs(app_name, [
         :slot_name,
-        :publication
+        :publication,
+        :durable_slot
       ])
 
     state = %{
       step: :disconnected,
       app_name: app_name,
       slot_name: slot_name,
-      publication: publication
+      publication: publication,
+      durable_slot: durable_slot
     }
 
     {:ok, state}
@@ -69,8 +75,13 @@ defmodule WalEx.Replication.Server do
 
   @impl true
   def handle_result([%Postgrex.Result{num_rows: 1}], state = %{step: :publication_exists}) do
-    query = QueryBuilder.create_temporary_slot(state)
-    {:query, query, %{state | step: :create_slot}}
+    if state.durable_slot do
+      query = QueryBuilder.slot_exists(state)
+      {:query, query, %{state | step: :slot_exists}}
+    else
+      query = QueryBuilder.create_temporary_slot(state)
+      {:query, query, %{state | step: :create_slot}}
+    end
   end
 
   @impl true
@@ -79,9 +90,41 @@ defmodule WalEx.Replication.Server do
   end
 
   @impl true
+  def handle_result([%Postgrex.Result{num_rows: 0}], state = %{step: :slot_exists}) do
+    query = QueryBuilder.create_durable_slot(state)
+    {:query, query, %{state | step: :create_slot}}
+  end
+
+  @impl true
+  def handle_result(
+        [%Postgrex.Result{columns: ["active"], rows: [[active]]}],
+        state = %{step: :slot_exists}
+      ) do
+    case active do
+      "f" ->
+        query = QueryBuilder.start_replication_slot(state)
+        {:stream, query, [], %{state | step: :streaming}}
+
+      "t" ->
+        raise "Durable slot already active"
+    end
+  end
+
+  @impl true
+  def handle_result(results, %{step: :slot_exists}) do
+    raise "Failed to check if durable slot already exists. #{inspect(results)}"
+  end
+
+  @impl true
   def handle_result([%Postgrex.Result{} | _results], state = %{step: :create_slot}) do
     query = QueryBuilder.start_replication_slot(state)
     {:stream, query, [], %{state | step: :streaming}}
+  end
+
+  @impl true
+  def handle_result(%Postgrex.Error{} = error, %{step: :create_slot}) do
+    # if durable slot, can happen if multiple instances try to create the same slot
+    raise "Failed to create replication slot, #{inspect(error)}"
   end
 
   @impl true

--- a/test/walex/config/config_test.exs
+++ b/test/walex/config/config_test.exs
@@ -92,7 +92,8 @@ defmodule WalEx.ConfigTest do
                destinations: [modules: [MyApp.CustomModule]],
                webhook_signing_secret: nil,
                event_relay: nil,
-               slot_name: "my_app_walex"
+               slot_name: "my_app_walex",
+               durable_slot: false
              ] == Config.get_configs(@app_name)
     end
   end

--- a/test/walex/config/config_test.exs
+++ b/test/walex/config/config_test.exs
@@ -93,7 +93,8 @@ defmodule WalEx.ConfigTest do
                webhook_signing_secret: nil,
                event_relay: nil,
                slot_name: "my_app_walex",
-               durable_slot: false
+               durable_slot: false,
+               start_location: "0/0"
              ] == Config.get_configs(@app_name)
     end
   end


### PR DESCRIPTION
add config option to start the replication slot at the desired LSN (XXX/XXX start location)
tried adding some tests but not easy to intercept the connection event or verify that our LSN is correctly being used.
Need to investigate / test what happens on server restart or db migration (is old wal address still valid) 