### PR TITLE
keep-alive reply: use wal_end+1 only if there a not transaction still being processed

### DIFF
--- a/lib/walex/changes.ex
+++ b/lib/walex/changes.ex
@@ -6,7 +6,7 @@ require Protocol
 defmodule WalEx.Changes do
   @moduledoc false
 
-  defmodule(Transaction, do: defstruct([:changes, :commit_timestamp]))
+  defmodule(Transaction, do: defstruct([:changes, :commit_timestamp, :lsn]))
 
   defmodule(NewRecord,
     do: defstruct([:type, :record, :schema, :table, :columns, :commit_timestamp, :lsn])

--- a/lib/walex/config/registry.ex
+++ b/lib/walex/config/registry.ex
@@ -5,6 +5,10 @@ defmodule WalEx.Config.Registry do
 
   @walex_registry :walex_registry
 
+  def child_spec() do
+    {Registry, keys: :unique, name: @walex_registry}
+  end
+
   def start_registry do
     case Process.whereis(@walex_registry) do
       nil ->

--- a/lib/walex/replication/progress.ex
+++ b/lib/walex/replication/progress.ex
@@ -1,0 +1,43 @@
+defmodule WalEx.Replication.Progress do
+  use Agent
+
+  alias WalEx.Config.Registry
+
+  @default_value :gb_sets.empty()
+
+  def start_link(opts) do
+    app_name = Keyword.fetch!(opts, :app_name)
+    name = Registry.set_name(:set_agent, __MODULE__, app_name)
+    Agent.start_link(fn -> @default_value end, name: name)
+  end
+
+  def reset(app_name) do
+    name = Registry.set_name(:set_agent, __MODULE__, app_name)
+    Agent.update(name, fn _ -> @default_value end)
+  end
+
+  @spec oldest_running_wal_end(any()) :: integer() | nil
+  def oldest_running_wal_end(app_name) do
+    still_running = current_state(app_name)
+
+    unless :gb_sets.is_empty(still_running) do
+      :gb_sets.smallest(still_running)
+    else
+      nil
+    end
+  end
+
+  def begin(app_name, {_, wal_end}) do
+    name = Registry.set_name(:set_agent, __MODULE__, app_name)
+    Agent.update(name, fn set -> :gb_sets.insert(wal_end, set) end)
+  end
+
+  def done(app_name, {_, wal_end}) do
+    name = Registry.set_name(:set_agent, __MODULE__, app_name)
+    Agent.update(name, fn set -> :gb_sets.del_element(wal_end, set) end)
+  end
+
+  defp current_state(app_name) do
+    Registry.get_state(:get_agent, __MODULE__, app_name)
+  end
+end

--- a/lib/walex/replication/publisher.ex
+++ b/lib/walex/replication/publisher.ex
@@ -67,9 +67,6 @@ defmodule WalEx.Replication.Publisher do
       )
       when commit_lsn == current_txn_lsn do
     Destinations.process(txn, app_name)
-
-    %{state | transaction: nil}
-
     {:noreply, state}
   end
 

--- a/lib/walex/replication/publisher.ex
+++ b/lib/walex/replication/publisher.ex
@@ -53,7 +53,7 @@ defmodule WalEx.Replication.Publisher do
       state
       | transaction: {
           final_lsn,
-          %Changes.Transaction{changes: [], commit_timestamp: commit_timestamp}
+          %Changes.Transaction{changes: [], commit_timestamp: commit_timestamp, lsn: final_lsn}
         }
     }
 

--- a/lib/walex/replication/server.ex
+++ b/lib/walex/replication/server.ex
@@ -7,6 +7,7 @@ defmodule WalEx.Replication.Server do
   """
   use Postgrex.ReplicationConnection
 
+  alias WalEx.Replication.Progress
   alias WalEx.Config.Registry, as: WalExRegistry
   alias WalEx.Decoder
   alias WalEx.Replication.Publisher
@@ -144,9 +145,11 @@ defmodule WalEx.Replication.Server do
   end
 
   def handle_data(<<?k, wal_end::64, _clock::64, reply>>, state) do
+    wal_end = Progress.oldest_running_wal_end(state.app_name) || wal_end + 1
+
     messages =
       case reply do
-        1 -> [<<?r, wal_end + 1::64, wal_end + 1::64, wal_end + 1::64, current_time()::64, 0>>]
+        1 -> [<<?r, wal_end::64, wal_end::64, wal_end::64, current_time()::64, 0>>]
         0 -> []
       end
 

--- a/lib/walex/replication/supervisor.ex
+++ b/lib/walex/replication/supervisor.ex
@@ -3,6 +3,7 @@ defmodule WalEx.Replication.Supervisor do
 
   use Supervisor
 
+  alias WalEx.Replication.Progress
   alias WalEx.Replication.{Publisher, Server}
 
   def start_link(opts) do
@@ -19,6 +20,7 @@ defmodule WalEx.Replication.Supervisor do
       |> Keyword.get(:app_name)
 
     children = [
+      {Progress, app_name: app_name},
       {Publisher, app_name: app_name},
       {Server, app_name: app_name}
     ]

--- a/test/walex/database_test.exs
+++ b/test/walex/database_test.exs
@@ -260,7 +260,7 @@ defmodule WalEx.DatabaseTest do
   end
 
   def pg_restart(:docker) do
-    case(System.shell("docker compose -f docker-compose.dbs.yml restart db")) do
+    case(System.shell("docker compose -f docker-compose.dbs.yml restart db -t 2")) do
       {_, 0} ->
         :ok
 

--- a/test/walex/event/event_test.exs
+++ b/test/walex/event/event_test.exs
@@ -78,7 +78,8 @@ defmodule WalEx.EventTest do
                  commit_timestamp: _updated_record_commit_timestamp
                }
              ],
-             commit_timestamp: _transaction_commit_timestamp
+             commit_timestamp: _transaction_commit_timestamp,
+             lsn: _lsn
            },
            :test_app
          }}

--- a/test/walex/replication/progress_test.exs
+++ b/test/walex/replication/progress_test.exs
@@ -1,0 +1,87 @@
+defmodule WalEx.Replication.ProgressTest do
+  use ExUnit.Case, async: false
+  alias WalEx.Replication.Publisher
+  alias WalEx.Replication.Progress
+  alias WalEx.Config.Registry
+
+  require Logger
+
+  @app_name :walex_test
+
+  setup_all do
+    {:ok, pid} = start_supervised(Registry.child_spec(), restart: :temporary)
+    %{registry_pid: pid}
+  end
+
+  describe "start" do
+    test "start_link is required" do
+      Process.flag(:trap_exit, true)
+
+      pid =
+        spawn_link(fn ->
+          Progress.begin(@app_name, {0, 1})
+        end)
+
+      assert_receive {:EXIT, ^pid, {:noproc, _}}
+    end
+  end
+
+  describe "usage" do
+    setup do
+      {:ok, pid} = start_supervised({Progress, app_name: @app_name}, restart: :temporary)
+      %{progress_pid: pid}
+    end
+
+    test "begin/end cancel each other" do
+      assert Progress.oldest_running_wal_end(@app_name) == nil
+
+      Progress.begin(@app_name, {0, 1})
+      Progress.done(@app_name, {0, 1})
+
+      assert Progress.oldest_running_wal_end(@app_name) == nil
+
+      :ok
+    end
+
+    test "oldest_running_wal_end" do
+      Progress.begin(@app_name, {0, 2})
+      Progress.begin(@app_name, {0, 3})
+      Progress.done(@app_name, {0, 2})
+
+      assert Progress.oldest_running_wal_end(@app_name) == 3
+
+      Progress.begin(@app_name, {0, 4})
+      Progress.done(@app_name, {0, 4})
+      assert Progress.oldest_running_wal_end(@app_name) == 3
+
+      Progress.done(@app_name, {0, 3})
+      assert Progress.oldest_running_wal_end(@app_name) == nil
+
+      :ok
+    end
+
+    test "oldest is is the smallest, doesn't care about insert order" do
+      Progress.begin(@app_name, {0, 20})
+      Progress.begin(@app_name, {0, 10})
+      Progress.begin(@app_name, {0, 5})
+      assert Progress.oldest_running_wal_end(@app_name) == 5
+      Progress.done(@app_name, {0, 5})
+      assert Progress.oldest_running_wal_end(@app_name) == 10
+      Progress.done(@app_name, {0, 20})
+      assert Progress.oldest_running_wal_end(@app_name) == 10
+      Progress.done(@app_name, {0, 10})
+      assert Progress.oldest_running_wal_end(@app_name) == nil
+
+      :ok
+    end
+
+    test "publisher restart resets progress" do
+      Progress.begin(@app_name, {0, 20})
+      Progress.begin(@app_name, {0, 10})
+      Progress.begin(@app_name, {0, 5})
+
+      assert {:ok, _pid} = start_supervised({Publisher, app_name: @app_name}, restart: :temporary)
+      assert Progress.oldest_running_wal_end(@app_name) == nil
+    end
+  end
+end


### PR DESCRIPTION
store in an Agent-managed :gb_sets the wal_ends of transactions
that are still being processed (event_module, web_hooks, etc.)

In the keep-live reply find the smallest wal_end in that Set if any.
Reply with that wal_end.

Replying with a wal_end greater than it would mean the Postgres server will consider it processed.
If the slot is non-temporary and we crash at this point the event would be lost.

If no transaction is in_progres reply with the received wal_end+1 like now.

On Publisher restart the progress gets reset