### PR TITLE
message_middleware: 

### DIFF
--- a/lib/walex/config/config.ex
+++ b/lib/walex/config/config.ex
@@ -4,9 +4,10 @@ defmodule WalEx.Config do
   """
   use Agent
 
+  alias WalEx.Replication.Publisher
   alias WalEx.Config.Registry, as: WalExRegistry
 
-  @allowed_config_value ~w(database hostname name password port publication username webhook_signing_secret slot_name durable_slot)a
+  @allowed_config_value ~w(database hostname name password port publication username webhook_signing_secret slot_name durable_slot message_middleware)a
   @allowed_config_values ~w(destinations event_relay modules subscriptions)a
 
   def start_link(opts) do
@@ -127,7 +128,8 @@ defmodule WalEx.Config do
       webhook_signing_secret: Keyword.get(configs, :webhook_signing_secret),
       event_relay: Keyword.get(configs, :event_relay),
       slot_name: Keyword.get(configs, :slot_name) |> parse_slot_name(name),
-      durable_slot: Keyword.get(configs, :durable_slot, false) == true
+      durable_slot: Keyword.get(configs, :durable_slot, false) == true,
+      message_middleware: Keyword.get(configs, :message_middleware) |> parse_message_middleware()
     ]
   end
 
@@ -199,6 +201,11 @@ defmodule WalEx.Config do
 
   defp parse_slot_name(nil, app_name), do: to_string(app_name) <> "_walex"
   defp parse_slot_name(slot_name, _), do: slot_name
+
+  defp parse_message_middleware(message_middleware) when is_function(message_middleware, 2),
+    do: message_middleware
+
+  defp parse_message_middleware(nil), do: &Publisher.process_message_async/2
 
   defp set_url_opts(username, password, database, info) do
     url_opts = [

--- a/lib/walex/config/config.ex
+++ b/lib/walex/config/config.ex
@@ -10,6 +10,29 @@ defmodule WalEx.Config do
   @allowed_config_value ~w(database hostname name password port publication username webhook_signing_secret slot_name durable_slot message_middleware)a
   @allowed_config_values ~w(destinations event_relay modules subscriptions)a
 
+  @type destinations_t :: [
+          {:modules, [module]} | {:webhooks, [binary]} | {:event_relay_topic, binary}
+        ]
+
+  @type start_opts :: [
+          {:database, binary}
+          | {:hostname, binary}
+          | {:name, binary}
+          | {:password, binary}
+          | {:port, binary}
+          | {:publication, binary}
+          | {:username, binary}
+          | {:webhook_signing_secret, binary}
+          | {:slot_name, binary}
+          | {:durable_slot, boolean}
+          | {:message_middleware, (term, term -> :ok)}
+          | {:destinations, destinations_t()}
+          | {:event_relay, keyword()}
+          | {:modules, [module]}
+          | {:subscriptions, [binary()]}
+        ]
+
+  @spec start_link(opts :: start_opts()) :: Agent.on_start()
   def start_link(opts) do
     configs =
       opts

--- a/lib/walex/replication/publisher.ex
+++ b/lib/walex/replication/publisher.ex
@@ -27,10 +27,14 @@ defmodule WalEx.Replication.Publisher do
     GenServer.start_link(__MODULE__, opts, name: name)
   end
 
-  def process_message(message, app_name) do
+  def process_message_async(message, app_name) do
     name = registry_name(app_name)
-
     GenServer.cast(name, %{message: message, app_name: app_name})
+  end
+
+  def process_message_sync(message, app_name) do
+    name = registry_name(app_name)
+    GenServer.call(name, %{message: message, app_name: app_name}, :infinity)
   end
 
   defp registry_name(app_name) do
@@ -45,40 +49,38 @@ defmodule WalEx.Replication.Publisher do
   end
 
   @impl true
-  def handle_cast(
-        %{message: %Messages.Begin{final_lsn: final_lsn, commit_timestamp: commit_timestamp}},
-        state
-      ) do
-    updated_state = %State{
+  def handle_cast(message, state), do: {:noreply, process_message(message, state)}
+
+  @impl true
+  def handle_call(message, _from, state), do: {:reply, :ok, process_message(message, state)}
+
+  defp process_message(
+         %{message: %Messages.Begin{final_lsn: final_lsn, commit_timestamp: commit_timestamp}},
+         state
+       ) do
+    %State{
       state
       | transaction: {
           final_lsn,
           %Changes.Transaction{changes: [], commit_timestamp: commit_timestamp}
         }
     }
-
-    {:noreply, updated_state}
   end
 
-  @impl true
-  def handle_cast(
-        %{message: %Messages.Commit{lsn: commit_lsn}, app_name: app_name},
-        %State{transaction: {current_txn_lsn, txn}, relations: _relations} = state
-      )
-      when commit_lsn == current_txn_lsn do
+  defp process_message(
+         %{message: %Messages.Commit{lsn: commit_lsn}, app_name: app_name},
+         %State{transaction: {current_txn_lsn, txn}, relations: _relations} = state
+       )
+       when commit_lsn == current_txn_lsn do
     Destinations.process(txn, app_name)
-    {:noreply, state}
+    state
   end
 
-  @impl true
-  def handle_cast(%{message: %Messages.Type{} = msg}, state) do
-    updated_state = %{state | types: Map.put(state.types, msg.id, msg.name)}
-
-    {:noreply, updated_state}
+  defp process_message(%{message: %Messages.Type{} = msg}, state) do
+    %{state | types: Map.put(state.types, msg.id, msg.name)}
   end
 
-  @impl true
-  def handle_cast(%{message: %Messages.Relation{} = msg}, state) do
+  defp process_message(%{message: %Messages.Relation{} = msg}, state) do
     updated_columns =
       Enum.map(msg.columns, fn message ->
         if Map.has_key?(state.types, message.type) do
@@ -89,20 +91,17 @@ defmodule WalEx.Replication.Publisher do
       end)
 
     updated_relations = %{msg | columns: updated_columns}
-    updated_state = %{state | relations: Map.put(state.relations, msg.id, updated_relations)}
-
-    {:noreply, updated_state}
+    %{state | relations: Map.put(state.relations, msg.id, updated_relations)}
   end
 
-  @impl true
-  def handle_cast(
-        %{message: %Messages.Insert{relation_id: relation_id, tuple_data: tuple_data}},
-        state = %State{
-          transaction: {lsn, %{commit_timestamp: commit_timestamp, changes: changes} = txn},
-          relations: relations
-        }
-      )
-      when is_map(relations) do
+  defp process_message(
+         %{message: %Messages.Insert{relation_id: relation_id, tuple_data: tuple_data}},
+         state = %State{
+           transaction: {lsn, %{commit_timestamp: commit_timestamp, changes: changes} = txn},
+           relations: relations
+         }
+       )
+       when is_map(relations) do
     case Map.fetch(relations, relation_id) do
       {:ok, %{columns: columns, namespace: namespace, name: name}} when is_list(columns) ->
         data = data_tuple_to_map(columns, tuple_data)
@@ -117,33 +116,30 @@ defmodule WalEx.Replication.Publisher do
           lsn: lsn
         }
 
-        updated_state = %State{
+        %State{
           state
           | transaction: {lsn, %{txn | changes: [new_record | changes]}}
         }
 
-        {:noreply, updated_state}
-
       _ ->
-        {:noreply, state}
+        state
     end
   end
 
-  @impl true
-  def handle_cast(
-        %{
-          message: %Messages.Update{
-            relation_id: relation_id,
-            old_tuple_data: old_tuple_data,
-            tuple_data: tuple_data
-          }
-        },
-        state = %State{
-          relations: relations,
-          transaction: {lsn, %{commit_timestamp: commit_timestamp, changes: changes} = txn}
-        }
-      )
-      when is_map(relations) do
+  defp process_message(
+         %{
+           message: %Messages.Update{
+             relation_id: relation_id,
+             old_tuple_data: old_tuple_data,
+             tuple_data: tuple_data
+           }
+         },
+         state = %State{
+           relations: relations,
+           transaction: {lsn, %{commit_timestamp: commit_timestamp, changes: changes} = txn}
+         }
+       )
+       when is_map(relations) do
     case Map.fetch(relations, relation_id) do
       {:ok, %{columns: columns, namespace: namespace, name: name}} when is_list(columns) ->
         old_data = data_tuple_to_map(columns, old_tuple_data)
@@ -160,33 +156,30 @@ defmodule WalEx.Replication.Publisher do
           lsn: lsn
         }
 
-        updated_state = %State{
+        %State{
           state
           | transaction: {lsn, %{txn | changes: [updated_record | changes]}}
         }
 
-        {:noreply, updated_state}
-
       _ ->
-        {:noreply, state}
+        state
     end
   end
 
-  @impl true
-  def handle_cast(
-        %{
-          message: %Messages.Delete{
-            relation_id: relation_id,
-            old_tuple_data: old_tuple_data,
-            changed_key_tuple_data: changed_key_tuple_data
-          }
-        },
-        state = %State{
-          relations: relations,
-          transaction: {lsn, %{commit_timestamp: commit_timestamp, changes: changes} = txn}
-        }
-      )
-      when is_map(relations) do
+  defp process_message(
+         %{
+           message: %Messages.Delete{
+             relation_id: relation_id,
+             old_tuple_data: old_tuple_data,
+             changed_key_tuple_data: changed_key_tuple_data
+           }
+         },
+         state = %State{
+           relations: relations,
+           transaction: {lsn, %{commit_timestamp: commit_timestamp, changes: changes} = txn}
+         }
+       )
+       when is_map(relations) do
     case Map.fetch(relations, relation_id) do
       {:ok, %{columns: columns, namespace: namespace, name: name}} when is_list(columns) ->
         data = data_tuple_to_map(columns, old_tuple_data || changed_key_tuple_data)
@@ -206,22 +199,21 @@ defmodule WalEx.Replication.Publisher do
           | transaction: {lsn, %{txn | changes: [deleted_record | changes]}}
         }
 
-        {:noreply, updated_state}
+        updated_state
 
       _ ->
-        {:noreply, state}
+        state
     end
   end
 
-  @impl true
-  def handle_cast(
-        %{message: %Messages.Truncate{truncated_relations: truncated_relations}},
-        state = %State{
-          relations: relations,
-          transaction: {lsn, %{commit_timestamp: commit_timestamp, changes: changes} = txn}
-        }
-      )
-      when is_list(truncated_relations) and is_list(changes) and is_map(relations) do
+  defp process_message(
+         %{message: %Messages.Truncate{truncated_relations: truncated_relations}},
+         state = %State{
+           relations: relations,
+           transaction: {lsn, %{commit_timestamp: commit_timestamp, changes: changes} = txn}
+         }
+       )
+       when is_list(truncated_relations) and is_list(changes) and is_map(relations) do
     new_changes =
       Enum.reduce(truncated_relations, changes, fn truncated_relation, acc ->
         case Map.fetch(relations, truncated_relation) do
@@ -247,11 +239,9 @@ defmodule WalEx.Replication.Publisher do
     }
   end
 
-  @impl true
-  def handle_cast(%{message: _message}, state) do
+  defp process_message(%{message: _message}, state) do
     :noop
-
-    {:noreply, state}
+    state
   end
 
   defp data_tuple_to_map(columns, tuple_data) when is_list(columns) and is_tuple(tuple_data) do

--- a/lib/walex/replication/server.ex
+++ b/lib/walex/replication/server.ex
@@ -138,7 +138,7 @@ defmodule WalEx.Replication.Server do
   def handle_data(<<?w, _wal_start::64, _wal_end::64, _clock::64, rest::binary>>, state) do
     rest
     |> Decoder.decode_message()
-    |> Publisher.process_message(state.app_name)
+    |> Publisher.process_message_async(state.app_name)
 
     {:noreply, state}
   end

--- a/lib/walex/supervisor.ex
+++ b/lib/walex/supervisor.ex
@@ -8,6 +8,7 @@ defmodule WalEx.Supervisor do
   alias WalEx.Replication.Supervisor, as: ReplicationSupervisor
   alias WalExConfig.Registry, as: WalExRegistry
 
+  @spec start_link(opts :: WalExConfig.start_opts()) :: Supervisor.on_start()
   def start_link(opts) do
     app_name = Keyword.get(opts, :name)
     module_names = build_module_names(app_name, opts)

--- a/test/walex/config/config_test.exs
+++ b/test/walex/config/config_test.exs
@@ -93,7 +93,8 @@ defmodule WalEx.ConfigTest do
                webhook_signing_secret: nil,
                event_relay: nil,
                slot_name: "my_app_walex",
-               durable_slot: false
+               durable_slot: false,
+               message_middleware: &WalEx.Replication.Publisher.process_message_async/2
              ] == Config.get_configs(@app_name)
     end
   end


### PR DESCRIPTION
make message passing from Replication.Server -> Replication.Publisher configurable

the aim of this is to allow the end user to implement a backpresure system if need be
for instance using broadway / dets / etc.