### PR TITLE
Syn decode in publisher

### DIFF
--- a/lib/walex/event/dsl.ex
+++ b/lib/walex/event/dsl.ex
@@ -1,6 +1,7 @@
 defmodule WalEx.Event.Dsl do
   defmacro process_events_async(events, functions) do
-    module = hd(__CALLER__.context_modules)
+    [_ | _] = __CALLER__.context_modules
+    module = List.first(__CALLER__.context_modules)
 
     quote do
       Enum.each(unquote(events), fn event ->

--- a/lib/walex/events/event_modules.ex
+++ b/lib/walex/events/event_modules.ex
@@ -27,6 +27,7 @@ defmodule WalEx.Events.EventModules do
 
   @impl true
   def init(_) do
+    Process.flag(:message_queue_data, :off_heap)
     {:ok, %{}}
   end
 

--- a/lib/walex/events/events.ex
+++ b/lib/walex/events/events.ex
@@ -30,6 +30,7 @@ defmodule WalEx.Events do
 
   @impl true
   def init(_) do
+    Process.flag(:message_queue_data, :off_heap)
     {:ok, %{}}
   end
 

--- a/lib/walex/replication/publisher.ex
+++ b/lib/walex/replication/publisher.ex
@@ -4,6 +4,7 @@ defmodule WalEx.Replication.Publisher do
   """
   use GenServer
 
+  alias WalEx.Decoder
   alias WalEx.{Changes, Config, Events, Types}
   alias WalEx.Decoder.Messages
 
@@ -53,6 +54,11 @@ defmodule WalEx.Replication.Publisher do
 
   @impl true
   def handle_call(message, _from, state), do: {:reply, :ok, process_message(message, state)}
+
+  defp process_message(%{message: {:raw, raw}} = message, state) do
+    decoded = Decoder.decode_message(raw)
+    process_message(%{message | message: decoded}, state)
+  end
 
   defp process_message(
          %{message: %Messages.Begin{final_lsn: final_lsn, commit_timestamp: commit_timestamp}},

--- a/lib/walex/replication/server.ex
+++ b/lib/walex/replication/server.ex
@@ -50,6 +50,8 @@ defmodule WalEx.Replication.Server do
       raw_messages: true
     }
 
+    Process.flag(:message_queue_data, :off_heap)
+
     {:ok, state}
   end
 

--- a/lib/walex/replication/server.ex
+++ b/lib/walex/replication/server.ex
@@ -46,7 +46,8 @@ defmodule WalEx.Replication.Server do
       slot_name: slot_name,
       publication: publication,
       durable_slot: durable_slot,
-      message_middleware: message_middleware
+      message_middleware: message_middleware,
+      raw_messages: true
     }
 
     {:ok, state}
@@ -137,6 +138,15 @@ defmodule WalEx.Replication.Server do
   def handle_result(_, state = %{step: {:start_replication, _retry_count, _backoff}}) do
     Logger.info("Successfully started replication slot: #{state.slot_name}")
     {:noreply, %{state | step: :streaming}}
+  end
+
+  @impl true
+  def handle_data(
+        <<?w, _wal_start::64, _wal_end::64, _clock::64, rest::binary>>,
+        %{raw_messages: true} = state
+      ) do
+    state.message_middleware.({:raw, rest}, state.app_name)
+    {:noreply, state}
   end
 
   @impl true


### PR DESCRIPTION
move decoding of raw binary messages out of the hot-path
might help reduce walex lag